### PR TITLE
Adjust grid positioning layout for printing

### DIFF
--- a/src/util/exporter.ts
+++ b/src/util/exporter.ts
@@ -362,14 +362,20 @@ export async function exportAsPdf(project: ProjectState, onProgress?: (p: number
 
   // Calendar grid with days and events
   const g = layout.grid;
-  const gx = g.x * width;
+  const baseGx = g.x * width;
   // Apply 0.25 inch top margin for 5x7 page size on the text (grid) side only
   const topMarginPt = project.calendar.pageSize === '5x7' ? (0.25 * 72) : 0;
   // Position the grid so the entire grid (including the header) is shifted DOWN by the top margin on 5x7
   // Keep the bottom the same and reduce height so the top drops by topMarginPt
-  const gy = height - (g.y * height) - (g.h * height);
-  const gw = g.w * width;
-  const gh = (g.h * height) - topMarginPt;
+  const baseGy = height - (g.y * height) - (g.h * height);
+  const baseGw = g.w * width;
+  const baseGh = (g.h * height) - topMarginPt;
+  // Uniform safe inset (1/8" = 9pt) around the calendar grid to avoid printer edge cropping
+  const safeInset = 0.125 * 72; // 9pt
+  const gx = baseGx + safeInset;
+  const gy = baseGy + safeInset;
+  const gw = Math.max(10, baseGw - safeInset * 2);
+  const gh = Math.max(10, baseGh - safeInset * 2);
   // Compute header metrics first
   const columns = 7 + (project.calendar.showWeekNumbers ? 1 : 0);
   const cellW = gw / columns;
@@ -379,7 +385,7 @@ export async function exportAsPdf(project: ProjectState, onProgress?: (p: number
   page.drawRectangle({ x: gx, y: gy + gh - cellH, width: gw, height: cellH + topMarginPt, color: rgb(0.96,0.96,0.96) });
   // Shade the week-number header cell slightly differently (to match preview), if enabled
   if (project.calendar.showWeekNumbers) {
-    page.drawRectangle({ x: gx, y: gy + gh - cellH, width: cellW, height: cellH, color: rgb(0.98,0.98,0.98) });
+  page.drawRectangle({ x: gx, y: gy + gh - cellH, width: cellW, height: cellH, color: rgb(0.98,0.98,0.98) });
   }
   // Month label inside grid header (bottom half)
   const labelSize = 16;
@@ -391,7 +397,7 @@ export async function exportAsPdf(project: ProjectState, onProgress?: (p: number
     const weekDayLabels = ['Sun','Mon','Tue','Wed','Thu','Fri','Sat'];
     // Header labels
     if (project.calendar.showWeekNumbers) {
-      page.drawText('Wk', { x: gx + 4, y: gy + gh - cellH + 4, size: 10, font, color: rgb(0,0,0) });
+  page.drawText('Wk', { x: gx + 4, y: gy + gh - cellH + 4, size: 10, font, color: rgb(0,0,0) });
     }
     weekDayLabels.forEach((d, i) => {
       const cx = gx + (i + (project.calendar.showWeekNumbers ? 1 : 0)) * cellW;


### PR DESCRIPTION
The calendar for 5x7 was being slightly cropped and printer settings had to be tinkered with. This pull request updates the calendar grid layout in the PDF export functionality to improve print reliability by adding a uniform safe inset around the grid. This change helps prevent edge cropping when printing calendars. Future printing will be easier instead of manually fighting the printer borderless print settings

Layout improvements for print safety:

* Added a uniform 1/8" (9pt) safe inset around the calendar grid by adjusting the calculation of `gx`, `gy`, `gw`, and `gh` in `exporter.ts`, ensuring that the grid is not cropped by printer margins.