### PR TITLE
Foldable calendar

### DIFF
--- a/FoldableSpecs.md
+++ b/FoldableSpecs.md
@@ -1,0 +1,16 @@
+# Page print order and layout for foldable calendars
+
+Page 1: Month 6 (month on bottom)
+Page 2: Month 5 (month on top, print upside-down)
+Page 3: Month 7 (month on bottom)
+Page 4: Month 4 (month on top, print upside-down)
+Page 5: Month 8 (month on bottom)
+Page 6: Month 3 (month on top, print upside-down)
+Page 7: Month 9 (month on bottom)
+Page 8: Month 2 (month on top, print upside-down)
+Page 9: Month 10 (month on bottom)
+Page 10: Month 1 (month on top, print upside-down)
+Page 11: Month 11 (month on bottom)
+Page 12: Month -1 (one before the start month, month on top, print upside-down)
+Page 13: Month 12 (month on bottom)
+Page 14: No month, this is the cover page, front cover pic on top upside down, rear cover photo on bottom

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -15,7 +15,7 @@ interface UIState {
   activeSlotId: string | null;
   eventDialog: { open: boolean; dateISO: string | null; editEventId: string | null };
   photoPicker: { open: boolean; monthIndex: number | null; slotId: string | null };
-  coverPicker?: { open: boolean; target: 'front' | 'rear' | null };
+  coverPicker?: { open: boolean; target: 'front' | 'rear' | 'legacy' | null };
   toasts: { id: string; text: string; type: 'info' | 'success' | 'error' }[];
   exportProgress: number; // 0..1
 }
@@ -71,7 +71,7 @@ interface Actions {
   assignPhotoToSlot(photoId: string, monthIndex: number, slotId: string): void;
   openPhotoPicker(monthIndex: number, slotId: string): void;
   closePhotoPicker(): void;
-  openCoverPicker(target: 'front' | 'rear'): void;
+  openCoverPicker(target: 'front' | 'rear' | 'legacy'): void;
   closeCoverPicker(): void;
 }
 interface StoreShape {

--- a/src/types.ts
+++ b/src/types.ts
@@ -33,6 +33,6 @@ export interface EventItem { id: string; dateISO: string; text: string; color?: 
 
 export type SplitDirection = 'tb' | 'lr'; // tb: top/bottom, lr: left/right
 export type CoverStyle = 'large-photo' | 'grid-4x3';
-export interface CalendarSettings { startMonth: number; startYear: number; months: number; layoutStylePerMonth: LayoutId[]; pageSize: CalendarPageSizeKey; orientation: Orientation; splitDirection: SplitDirection; showCommonHolidays?: boolean; includeCoverPage?: boolean; coverStyle?: CoverStyle; coverPhotoId?: string; coverTransform?: PhotoTransform; fontFamily: string; }
+export interface CalendarSettings { startMonth: number; startYear: number; months: number; layoutStylePerMonth: LayoutId[]; pageSize: CalendarPageSizeKey; orientation: Orientation; splitDirection: SplitDirection; showCommonHolidays?: boolean; includeCoverPage?: boolean; coverStyle?: CoverStyle; coverPhotoId?: string; frontCoverPhotoId?: string; rearCoverPhotoId?: string; coverTransform?: PhotoTransform; frontCoverTransform?: PhotoTransform; rearCoverTransform?: PhotoTransform; fontFamily: string; }
 
 export interface ProjectState { id: string; meta: { createdAt: string; updatedAt: string; appVersion: string; schemaVersion: number; }; calendar: CalendarSettings; photos: PhotoMeta[]; coverPhotos: PhotoMeta[]; monthData: MonthPage[]; events: EventItem[]; }

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -5,7 +5,7 @@ import { RightPanel } from './components/RightPanel';
 import { useCalendarStore } from '../store/store';
 import { EventModal } from './components/EventModal';
 import { ToastHost } from './components/ToastHost';
-import { PhotoPickerModal } from './components/PhotoPickerModal';
+import { PhotoPickerModal, CoverPhotoPickerModal } from './components/PhotoPickerModal';
 
 export const App: React.FC = () => {
   const dark = useCalendarStore(s => s.ui.darkMode);
@@ -50,6 +50,7 @@ export const App: React.FC = () => {
   <EventModal />
   <ToastHost />
   <PhotoPickerModal />
+  <CoverPhotoPickerModal />
     </div>
   );
 };

--- a/src/ui/components/CoverPhotoUnifiedPreview.tsx
+++ b/src/ui/components/CoverPhotoUnifiedPreview.tsx
@@ -1,0 +1,88 @@
+import React, { useRef } from 'react';
+import { useCalendarStore } from '../../store/store';
+import { computePagePixelSize } from '../../util/pageSize';
+
+interface UnifiedCoverPreviewProps {
+  which: 'legacy' | 'front' | 'rear';
+  label: string;
+}
+
+// Re-usable preview matching month photo interaction (pan/zoom/rotate + overlay controls)
+export const CoverPhotoUnifiedPreview: React.FC<UnifiedCoverPreviewProps> = ({ which, label }) => {
+  const {
+    pageSize, orientation,
+    photoId, transform,
+    setLegacy, setFront, setRear,
+    updateLegacy, updateFront, updateRear,
+    resetLegacy, resetFront, resetRear,
+    openPicker
+  } = useCalendarStore(s => ({
+    pageSize: s.project.calendar.pageSize,
+    orientation: s.project.calendar.orientation,
+    photoId: which === 'legacy' ? s.project.calendar.coverPhotoId : (which === 'front' ? s.project.calendar.frontCoverPhotoId : s.project.calendar.rearCoverPhotoId),
+    transform: which === 'legacy' ? (s.project.calendar.coverTransform || { scale:1, translateX:0, translateY:0, rotationDegrees:0 }) : (which === 'front' ? (s.project.calendar.frontCoverTransform || { scale:1, translateX:0, translateY:0, rotationDegrees:0 }) : (s.project.calendar.rearCoverTransform || { scale:1, translateX:0, translateY:0, rotationDegrees:0 })),
+    setLegacy: s.actions.setCoverPhoto,
+    setFront: s.actions.setFrontCoverPhoto,
+    setRear: s.actions.setRearCoverPhoto,
+    updateLegacy: s.actions.updateCoverTransform,
+    updateFront: s.actions.updateFrontCoverTransform,
+    updateRear: s.actions.updateRearCoverTransform,
+    resetLegacy: s.actions.resetCoverTransform,
+    resetFront: s.actions.resetFrontCoverTransform,
+    resetRear: s.actions.resetRearCoverTransform,
+    openPicker: s.actions.openCoverPicker
+  }));
+  const coverPhotos = useCalendarStore(s => s.project.coverPhotos);
+  const allPhotos = useCalendarStore(s => s.project.photos);
+  const photo = coverPhotos.find(p => p.id === photoId) || allPhotos.find(p => p.id === photoId);
+  const px = computePagePixelSize(pageSize, orientation, 100);
+  const dragRef = useRef<{ active:boolean; startX:number; startY:number; startTX:number; startTY:number }|null>(null);
+  const update = (delta: Partial<{ scale:number; translateX:number; translateY:number; rotationDegrees:number }>) => {
+    if (which === 'legacy') updateLegacy(delta);
+    else if (which === 'front') updateFront(delta);
+    else updateRear(delta);
+  };
+  const reset = () => { if (which === 'legacy') resetLegacy(); else if (which === 'front') resetFront(); else resetRear(); };
+  const clear = () => { if (which === 'legacy') setLegacy(null); else if (which === 'front') setFront(null); else setRear(null); };
+  const openSelect = () => { if (which === 'legacy') { /* reuse legacy adding process: open picker for front, fallback */ openPicker('front'); } else openPicker(which as 'front' | 'rear'); };
+  const onPointerDown: React.PointerEventHandler<HTMLDivElement> = e => {
+    if (!photo) { openSelect(); return; }
+    const target = e.target as HTMLElement; if (target.closest('[data-controls]')) return;
+    try { (e.currentTarget as any).setPointerCapture?.(e.pointerId); } catch {}
+    dragRef.current = { active:true, startX:e.clientX, startY:e.clientY, startTX: transform.translateX||0, startTY: transform.translateY||0 };
+    e.preventDefault();
+  };
+  const onPointerMove: React.PointerEventHandler<HTMLDivElement> = e => {
+    const d = dragRef.current; if (!d?.active) return; e.preventDefault();
+    const rect = e.currentTarget.getBoundingClientRect();
+    const nx = d.startTX + (e.clientX - d.startX)/rect.width;
+    const ny = d.startTY + (e.clientY - d.startY)/rect.height;
+    update({ translateX: nx, translateY: ny });
+  };
+  const end = () => { if (dragRef.current) dragRef.current.active = false; };
+  const onWheel: React.WheelEventHandler<HTMLDivElement> = e => { e.preventDefault(); const factor = e.deltaY < 0 ? 1.1 : 1/1.1; update({ scale: (transform.scale||1)*factor }); };
+  const tx = (transform.translateX||0)*100; const ty = (transform.translateY||0)*100;
+  const style: React.CSSProperties = { transform:`translate(-50%, -50%) translate(${tx}%, ${ty}%) scale(${transform.scale||1}) rotate(${transform.rotationDegrees||0}deg)`, transformOrigin:'center center' };
+  return (
+    <div className="w-full">
+      <div className="text-[11px] font-medium mb-1 flex items-center justify-between">
+        <span>{label}</span>
+        {photoId && <button onClick={clear} className="text-[10px] text-red-600 hover:underline">Clear</button>}
+      </div>
+      <div className="relative w-full rounded border border-gray-300 dark:border-gray-600 bg-gray-200 dark:bg-gray-700 overflow-hidden select-none" style={{ aspectRatio: `${px.width} / ${px.height}`, touchAction:'none' }} onPointerDown={onPointerDown} onPointerMove={onPointerMove} onPointerUp={end} onPointerCancel={end} onWheel={onWheel} onDoubleClick={openSelect}>
+        {!photo && <button type="button" onClick={openSelect} className="absolute inset-0 flex items-center justify-center text-gray-600 dark:text-gray-300 hover:bg-gray-300/30 text-[10px]">Click to choose</button>}
+        {photo?.previewUrl && <img src={photo.previewUrl} alt={photo.name} className="absolute left-1/2 top-1/2 w-[130%] h-[130%] object-cover" style={style} draggable={false} />}
+        {photo && (
+          <div data-controls className="absolute bottom-1 left-1 right-1 flex flex-wrap gap-1 bg-white/80 dark:bg-gray-900/80 backdrop-blur p-1 rounded text-[9px]">
+            <button onClick={() => update({ scale:(transform.scale||1)*1.1 })} className="px-1 py-0.5 bg-gray-300 dark:bg-gray-600 rounded">+</button>
+            <button onClick={() => update({ scale:(transform.scale||1)/1.1 })} className="px-1 py-0.5 bg-gray-300 dark:bg-gray-600 rounded">-</button>
+            <button onClick={() => update({ rotationDegrees:(transform.rotationDegrees||0)+90 })} className="px-1 py-0.5 bg-gray-300 dark:bg-gray-600 rounded">⟳</button>
+            <button onClick={() => update({ translateX:0, translateY:0 })} className="px-1 py-0.5 bg-gray-300 dark:bg-gray-600 rounded">Center</button>
+            <button onClick={reset} className="px-1 py-0.5 bg-red-500 text-white rounded">Reset</button>
+            <button onClick={openSelect} className="px-1 py-0.5 bg-blue-600 text-white rounded">Change</button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/src/ui/components/PhotoPickerModal.tsx
+++ b/src/ui/components/PhotoPickerModal.tsx
@@ -58,3 +58,37 @@ export const PhotoPickerModal: React.FC = () => {
     </div>
   );
 };
+
+export const CoverPhotoPickerModal: React.FC = () => {
+  const { isOpen, target, photos, actions } = useCalendarStore(s => ({
+    isOpen: s.ui.coverPicker?.open,
+    target: s.ui.coverPicker?.target,
+    photos: s.project.coverPhotos.length ? s.project.coverPhotos : s.project.photos,
+    actions: s.actions
+  }), shallow);
+  if (!isOpen || !target) return null;
+  const handleSelect = (photoId: string) => {
+    if (target === 'front') actions.setFrontCoverPhoto(photoId);
+    else actions.setRearCoverPhoto(photoId);
+    actions.closeCoverPicker();
+  };
+  return (
+    <div className="fixed inset-0 bg-black/50 z-50 flex items-center justify-center" onClick={actions.closeCoverPicker}>
+      <div className="bg-white dark:bg-gray-800 rounded-lg shadow-xl p-4 w-full max-w-3xl max-h-[80vh] flex flex-col" onClick={e => e.stopPropagation()}>
+        <h2 className="text-lg font-bold mb-4 text-gray-900 dark:text-gray-100">Select {target === 'front' ? 'Front' : 'Rear'} Cover Photo</h2>
+        <div className="grid grid-cols-4 md:grid-cols-6 lg:grid-cols-8 gap-4 overflow-auto">
+          {photos.map(photo => (
+            <button key={photo.id} onClick={() => handleSelect(photo.id)} className="relative group border border-gray-300 dark:border-gray-600 rounded overflow-hidden aspect-square bg-gray-100 dark:bg-gray-700">
+              {photo.previewUrl ? <img src={photo.previewUrl} alt={photo.name} className="object-cover w-full h-full" /> : <span className="text-xs p-1">{photo.name}</span>}
+              <div className="absolute inset-0 bg-black/0 group-hover:bg-black/40 flex items-center justify-center transition-all"><span className="text-white opacity-0 group-hover:opacity-100">Select</span></div>
+            </button>
+          ))}
+          {photos.length === 0 && <p className="col-span-full text-center text-gray-500 dark:text-gray-400 text-sm">No cover photos uploaded yet.</p>}
+        </div>
+        <div className="mt-4 text-right">
+          <button onClick={actions.closeCoverPicker} className="px-3 py-1.5 bg-gray-200 dark:bg-gray-700 rounded text-sm">Cancel</button>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/ui/components/PhotoPickerModal.tsx
+++ b/src/ui/components/PhotoPickerModal.tsx
@@ -69,13 +69,14 @@ export const CoverPhotoPickerModal: React.FC = () => {
   if (!isOpen || !target) return null;
   const handleSelect = (photoId: string) => {
     if (target === 'front') actions.setFrontCoverPhoto(photoId);
-    else actions.setRearCoverPhoto(photoId);
+    else if (target === 'rear') actions.setRearCoverPhoto(photoId);
+    else if (target === 'legacy') actions.setCoverPhoto(photoId);
     actions.closeCoverPicker();
   };
   return (
     <div className="fixed inset-0 bg-black/50 z-50 flex items-center justify-center" onClick={actions.closeCoverPicker}>
       <div className="bg-white dark:bg-gray-800 rounded-lg shadow-xl p-4 w-full max-w-3xl max-h-[80vh] flex flex-col" onClick={e => e.stopPropagation()}>
-        <h2 className="text-lg font-bold mb-4 text-gray-900 dark:text-gray-100">Select {target === 'front' ? 'Front' : 'Rear'} Cover Photo</h2>
+  <h2 className="text-lg font-bold mb-4 text-gray-900 dark:text-gray-100">Select {target === 'front' ? 'Front' : target === 'rear' ? 'Rear' : 'Cover'} Photo</h2>
         <div className="grid grid-cols-4 md:grid-cols-6 lg:grid-cols-8 gap-4 overflow-auto">
           {photos.map(photo => (
             <button key={photo.id} onClick={() => handleSelect(photo.id)} className="relative group border border-gray-300 dark:border-gray-600 rounded overflow-hidden aspect-square bg-gray-100 dark:bg-gray-700">

--- a/src/ui/components/RightPanel.tsx
+++ b/src/ui/components/RightPanel.tsx
@@ -29,12 +29,17 @@ export const RightPanel: React.FC = () => {
 
 const ExportButton: React.FC = () => {
   const exportProject = useCalendarStore(s => s.actions.exportProject);
+  const exportProjectFoldable = useCalendarStore(s => s.actions.exportProjectFoldable);
   const exporting = useCalendarStore(s => s.ui.exporting);
   const progress = useCalendarStore(s => s.ui.exportProgress);
+  const pageSize = useCalendarStore(s => s.project.calendar.pageSize);
   return (
     <div>
       <button disabled={exporting} onClick={exportProject} className="px-3 py-2 rounded bg-blue-600 hover:bg-blue-700 disabled:opacity-50 text-white text-sm w-full">
         {exporting ? `Exporting… ${Math.round(progress*100)}%` : 'Export PDF'}
+      </button>
+      <button disabled={exporting || pageSize === '5x7'} onClick={exportProjectFoldable} className="mt-2 px-3 py-2 rounded bg-indigo-600 hover:bg-indigo-700 disabled:opacity-50 text-white text-sm w-full">
+        {exporting ? `Exporting… ${Math.round(progress*100)}%` : 'Export PDF Foldable'}
       </button>
       {exporting && (
         <div className="mt-2 h-2 bg-gray-200 dark:bg-gray-700 rounded overflow-hidden">

--- a/src/ui/components/Sidebar.tsx
+++ b/src/ui/components/Sidebar.tsx
@@ -120,13 +120,11 @@ export const Sidebar: React.FC = () => {
                     <input type="file" accept="image/*" multiple className="hidden" onChange={e => { if (e.target.files) useCalendarStore.getState().actions.addCoverPhotos(e.target.files); e.target.value=''; }} />
                     <div className="border border-dashed border-gray-400 dark:border-gray-600 rounded p-2 text-center text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-900">Click to choose</div>
                   </label>
-          {(state.coverPhotoId || state.frontCoverPhotoId || state.rearCoverPhotoId) && (
-            <div className="space-y-4">
+          <div className="space-y-4">
               <CoverPhotoUnifiedPreview which="legacy" label="Legacy Cover" />
               <CoverPhotoUnifiedPreview which="front" label="Front (inverted)" />
               <CoverPhotoUnifiedPreview which="rear" label="Rear" />
             </div>
-          )}
                 </div>
               )}
             </label>
@@ -172,6 +170,9 @@ export const Sidebar: React.FC = () => {
     </aside>
   );
 };
+
+// Provide a default export too (some bundlers / HMR edge cases were not seeing the named export)
+export default Sidebar;
 
 // Interactive cover preview with pan/zoom/rotate controls (normalized like month slots)
 const CoverPreview: React.FC<{ photoId: string }> = ({ photoId }) => {

--- a/src/ui/components/Sidebar.tsx
+++ b/src/ui/components/Sidebar.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useRef, useState, useLayoutEffect } from 'react';
 import { createPortal } from 'react-dom';
 import { computePagePixelSize } from '../../util/pageSize';
+import { CoverPhotoUnifiedPreview } from './CoverPhotoUnifiedPreview';
 import { useCalendarStore } from '../../store/store';
 import { SIZES, LAYOUTS } from '../../util/constants';
 import type { CalendarPageSizeKey, LayoutId } from '../../types';
@@ -120,21 +121,12 @@ export const Sidebar: React.FC = () => {
                     <div className="border border-dashed border-gray-400 dark:border-gray-600 rounded p-2 text-center text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-900">Click to choose</div>
                   </label>
           {(state.coverPhotoId || state.frontCoverPhotoId || state.rearCoverPhotoId) && (
-                    <div>
-                      <div className="text-[11px] mb-1 text-gray-600 dark:text-gray-300">Selected legacy single cover preview</div>
-            {state.coverPhotoId && <CoverPreview photoId={state.coverPhotoId} />}
-            <div className="mt-3 space-y-2">
-              <div className="text-[11px] font-medium">Foldable Front / Rear Cover (optional)</div>
-              <div className="space-y-3">
-                <FoldableCoverInteractive which="front" label="Front (inverted)" />
-                <FoldableCoverInteractive which="rear" label="Rear" />
-              </div>
+            <div className="space-y-4">
+              <CoverPhotoUnifiedPreview which="legacy" label="Legacy Cover" />
+              <CoverPhotoUnifiedPreview which="front" label="Front (inverted)" />
+              <CoverPhotoUnifiedPreview which="rear" label="Rear" />
             </div>
-                      <div className="mt-2">
-                        <button type="button" onClick={() => state.setCoverPhoto(null)} className="text-xs text-red-600 hover:underline">Clear cover photo</button>
-                      </div>
-                    </div>
-                  )}
+          )}
                 </div>
               )}
             </label>
@@ -359,70 +351,3 @@ const PhotoList: React.FC = () => {
 };
 
 
-// Interactive preview + controls (drag/pan/zoom/rotate) for front/rear foldable cover halves
-const FoldableCoverInteractive: React.FC<{ which: 'front' | 'rear'; label: string }> = ({ which, label }) => {
-  const { pageSize, orientation } = useCalendarStore(s => ({ pageSize: s.project.calendar.pageSize, orientation: s.project.calendar.orientation }));
-  const photoId = useCalendarStore(s => which === 'front' ? s.project.calendar.frontCoverPhotoId : s.project.calendar.rearCoverPhotoId);
-  const photo = useCalendarStore(s => s.project.coverPhotos.find(p => p.id === photoId) || s.project.photos.find(p => p.id === photoId));
-  const t = useCalendarStore(s => which === 'front' ? (s.project.calendar.frontCoverTransform || { scale:1, translateX:0, translateY:0, rotationDegrees:0 }) : (s.project.calendar.rearCoverTransform || { scale:1, translateX:0, translateY:0, rotationDegrees:0 }));
-  const update = useCalendarStore(s => which === 'front' ? s.actions.updateFrontCoverTransform : s.actions.updateRearCoverTransform);
-  const reset = useCalendarStore(s => which === 'front' ? s.actions.resetFrontCoverTransform : s.actions.resetRearCoverTransform);
-  const openPicker = () => useCalendarStore.getState().actions.openCoverPicker(which);
-  const dragRef = React.useRef<{ active:boolean; startX:number; startY:number; startTX:number; startTY:number; lockScrollX:number; lockScrollY:number }|null>(null);
-  const onPointerDown: React.PointerEventHandler<HTMLDivElement> = e => {
-    e.preventDefault(); // suppress native behaviors immediately
-    if (!photo) { openPicker(); return; }
-    const target = e.target as HTMLElement;
-    if (target.closest('[data-controls]')) return;
-    try { (e.currentTarget as any).setPointerCapture?.(e.pointerId); } catch {}
-    dragRef.current = { active:true, startX:e.clientX, startY:e.clientY, startTX:t.translateX||0, startTY:t.translateY||0, lockScrollX: window.scrollX, lockScrollY: window.scrollY };
-    // Lock body scroll (desktop + mobile) while dragging
-    document.documentElement.style.scrollBehavior = 'auto';
-    document.body.style.overscrollBehavior = 'contain';
-    document.body.style.touchAction = 'none';
-    document.body.style.userSelect = 'none';
-  };
-  const onPointerMove: React.PointerEventHandler<HTMLDivElement> = e => {
-    const d = dragRef.current; if (!d?.active) return;
-    e.preventDefault(); // prevent scroll / text selection
-    // Restore scroll position if browser attempted to move it
-    window.scrollTo(d.lockScrollX, d.lockScrollY);
-    const rect = e.currentTarget.getBoundingClientRect();
-    update({ translateX: d.startTX + (e.clientX - d.startX)/rect.width, translateY: d.startTY + (e.clientY - d.startY)/rect.height });
-  };
-  const end = () => {
-    if (dragRef.current) dragRef.current.active = false;
-    // Restore body styles
-    document.body.style.overscrollBehavior = '';
-    document.body.style.touchAction = '';
-    document.body.style.userSelect = '';
-  };
-  const onWheel: React.WheelEventHandler<HTMLDivElement> = e => { e.preventDefault(); const factor = e.deltaY < 0 ? 1.1 : 1/1.1; update({ scale: (t.scale||1)*factor }); };
-  const tx = (t.translateX||0)*100; const ty = (t.translateY||0)*100;
-  const style: React.CSSProperties = { transform:`translate(-50%, -50%) translate(${tx}%, ${ty}%) scale(${t.scale||1}) rotate(${t.rotationDegrees||0}deg)`, transformOrigin:'center center' };
-  // Use same page aspect ratio as standard cover preview for consistency
-  const px = computePagePixelSize(pageSize, orientation, 100);
-  return (
-  <div className="relative w-full rounded border border-gray-300 dark:border-gray-600 bg-gray-200 dark:bg-gray-700 overflow-hidden text-[10px] select-none" style={{ aspectRatio: `${px.width} / ${px.height}`, touchAction: 'none', overscrollBehavior: 'contain' }} onPointerDown={onPointerDown} onPointerMove={onPointerMove} onPointerUp={end} onPointerCancel={end} onDoubleClick={openPicker} onWheel={onWheel}>
-      {!photo && (
-        <button type="button" onClick={openPicker} className="absolute inset-0 flex items-center justify-center text-gray-600 dark:text-gray-300 hover:bg-gray-300/30">
-          {label}\nClick to choose
-        </button>
-      )}
-      {photo?.previewUrl && (
-        <>
-          <img src={photo.previewUrl} alt={label} className="absolute left-1/2 top-1/2 w-[130%] h-[130%] object-cover" style={style} draggable={false} />
-          <div className="absolute bottom-1 left-1 right-1 flex flex-wrap gap-1 justify-start bg-white/80 dark:bg-gray-900/80 backdrop-blur px-1 py-0.5 rounded text-[9px]" data-controls>
-            <span className="font-semibold mr-1">{label}</span>
-            <button onClick={() => update({ scale:(t.scale||1)*1.1 })} className="px-1 py-0.5 bg-gray-300 dark:bg-gray-600 rounded">+</button>
-            <button onClick={() => update({ scale:(t.scale||1)/1.1 })} className="px-1 py-0.5 bg-gray-300 dark:bg-gray-600 rounded">-</button>
-            <button onClick={() => update({ rotationDegrees:(t.rotationDegrees||0)+90 })} className="px-1 py-0.5 bg-gray-300 dark:bg-gray-600 rounded">⟳</button>
-            <button onClick={() => update({ translateX:0, translateY:0 })} className="px-1 py-0.5 bg-gray-300 dark:bg-gray-600 rounded">Center</button>
-            <button onClick={() => reset()} className="px-1 py-0.5 bg-red-500 text-white rounded">Reset</button>
-            <button onClick={openPicker} className="px-1 py-0.5 bg-blue-600 text-white rounded">Change</button>
-          </div>
-        </>
-      )}
-    </div>
-  );
-};

--- a/src/util/defaultProject.ts
+++ b/src/util/defaultProject.ts
@@ -19,7 +19,11 @@ export function defaultProject(): ProjectState {
   includeCoverPage: false,
   coverStyle: 'large-photo',
   coverPhotoId: undefined as any,
+  frontCoverPhotoId: undefined as any,
+  rearCoverPhotoId: undefined as any,
   coverTransform: { scale: 1, translateX: 0, translateY: 0, rotationDegrees: 0 },
+  frontCoverTransform: { scale: 1, translateX: 0, translateY: 0, rotationDegrees: 0 },
+  rearCoverTransform: { scale: 1, translateX: 0, translateY: 0, rotationDegrees: 0 },
   fontFamily: 'Inter'
     },
     photos: [],

--- a/src/util/exporter.ts
+++ b/src/util/exporter.ts
@@ -1,4 +1,4 @@
-import { PDFDocument, StandardFonts, rgb } from 'pdf-lib';
+import { PDFDocument, StandardFonts, rgb, degrees } from 'pdf-lib';
 // @ts-ignore - fontkit types not provided by default
 import fontkit from '@pdf-lib/fontkit';
 import type { ProjectState } from '../types';
@@ -497,4 +497,177 @@ function parseHexColor(hex?: string) {
     return rgb(r,g,b);
   }
   return rgb(0,0,0);
+}
+
+// Foldable calendar export per FoldableSpecs.md
+// The spec defines a custom print order of months (some upside-down) plus cover.
+// We implement by reusing the normal month rendering path but optionally rotating
+// pages 180 degrees when they are designated "print upside-down" and by mapping
+// the requested month index relative to the project's start month.
+// Special month indices:
+//  - Month -1 represents the month before the starting month.
+//  - Cover page (page 14) includes existing cover layout but arranged with front (top, inverted) and back (bottom) placeholders/photos.
+// For MVP we will: reuse existing cover export for cover (no dual photo) and simply append it last.
+// Pages requiring upside-down print will be rotated by 180 degrees (content drawn normally then rotated). For simplicity we render onto a separate page and rotate at end.
+export async function exportAsPdfFoldable(project: ProjectState, onProgress?: (p: number) => void) {
+  // Disallow 5x7 per requirement (UI should prevent calling; safeguard here too)
+  if (project.calendar.pageSize === '5x7') throw new Error('Foldable export not supported for 5x7');
+  const pdf = await PDFDocument.create();
+  try { (pdf as any).registerFontkit?.(fontkit); } catch {}
+  const font = await embedSelectedFont(pdf, project.calendar.fontFamily);
+
+  interface PageSpec { label: string; monthOffset: number | null; upsideDown?: boolean; }
+  // Build ordered spec list (excluding final cover which we'll treat separately)
+  const pageSpecs: PageSpec[] = [
+    { label: 'Month 6', monthOffset: 5, upsideDown: false }, // bottom
+    { label: 'Month 5', monthOffset: 4, upsideDown: true },
+    { label: 'Month 7', monthOffset: 6, upsideDown: false },
+    { label: 'Month 4', monthOffset: 3, upsideDown: true },
+    { label: 'Month 8', monthOffset: 7, upsideDown: false },
+    { label: 'Month 3', monthOffset: 2, upsideDown: true },
+    { label: 'Month 9', monthOffset: 8, upsideDown: false },
+    { label: 'Month 2', monthOffset: 1, upsideDown: true },
+    { label: 'Month 10', monthOffset: 9, upsideDown: false },
+    { label: 'Month 1', monthOffset: 0, upsideDown: true },
+    { label: 'Month 11', monthOffset: 10, upsideDown: false },
+    { label: 'Month -1', monthOffset: -1, upsideDown: true },
+    { label: 'Month 12', monthOffset: 11, upsideDown: false }
+  ];
+  // Filter by actual number of months in project (months beyond range skipped, except -1 if valid)
+  const monthsCount = project.calendar.months;
+  const validSpecs = pageSpecs.filter(ps => {
+    if (ps.monthOffset === -1) return true; // allow attempt; we will synthesize prior month grid
+    return ps.monthOffset! >= 0 && ps.monthOffset! < monthsCount;
+  });
+  const hasCover = !!project.calendar.includeCoverPage; // cover appended after foldable pages
+  const totalPages = validSpecs.length + (hasCover ? 1 : 0);
+  let pageCounter = 0;
+
+  for (const ps of validSpecs) {
+    const { pageSize, orientation, splitDirection } = project.calendar;
+    const pt = computePagePixelSize(pageSize, orientation, 72);
+    const px = computePagePixelSize(pageSize, orientation, 300);
+    const page = pdf.addPage([pt.width, pt.height]);
+    const { width, height } = page.getSize();
+    let monthIndex = ps.monthOffset!; // may be -1
+    // Compute real calendar month/year and layout index (clamp for -1)
+    const startMonth = project.calendar.startMonth;
+    const startYear = project.calendar.startYear;
+    let realMonth0: number; let realYear: number; let layoutIdx: number;
+    if (monthIndex === -1) {
+      // month before start
+      const beforeTotal = startMonth - 1;
+      realMonth0 = (beforeTotal + 12) % 12;
+      realYear = startYear + Math.floor((startMonth - 1) / 12); // integer division toward zero is fine for positive years
+      layoutIdx = 0; // reuse first layout pattern
+    } else {
+      const totalOffset = startMonth + monthIndex;
+      realMonth0 = totalOffset % 12;
+      realYear = startYear + Math.floor(totalOffset / 12);
+      layoutIdx = monthIndex;
+    }
+    const layoutId = project.calendar.layoutStylePerMonth[Math.max(0, Math.min(project.calendar.layoutStylePerMonth.length - 1, layoutIdx))];
+    const layout = getEffectiveLayout(layoutId, splitDirection)!;
+    // Photo slots (synthesizing empty for -1)
+    if (monthIndex >= 0) {
+      const monthPage = project.monthData[monthIndex];
+      for (const slot of layout.slots) {
+        const slotPointW = slot.rect.w * width;
+        const slotPointH = slot.rect.h * height;
+        const slotPixelW = Math.max(1, Math.round(slot.rect.w * px.width));
+        const slotPixelH = Math.max(1, Math.round(slot.rect.h * px.height));
+        const s = monthPage.slots.find(ss => ss.slotId === slot.slotId);
+        const photo = s?.photoId ? project.photos.find(p => p.id === s.photoId) : undefined;
+        const x = slot.rect.x * width;
+        const y = height - (slot.rect.y * height) - slotPointH;
+        if (!s || !photo?.previewUrl) {
+          page.drawRectangle({ x, y, width: slotPointW, height: slotPointH, borderColor: rgb(0.3,0.5,0.9), borderWidth: 1 });
+        } else {
+          const img = await loadImage(photo.previewUrl);
+            const canvas = document.createElement('canvas');
+            canvas.width = slotPixelW; canvas.height = slotPixelH;
+            const ctx = canvas.getContext('2d')!;
+            ctx.imageSmoothingEnabled = true; ctx.imageSmoothingQuality = 'high';
+            const t = s.transform;
+            const baseScale = Math.max(slotPixelW / img.width, slotPixelH / img.height);
+            const scale = baseScale * (t.scale || 1);
+            const tx = (t.translateX || 0) * slotPixelW;
+            const ty = (t.translateY || 0) * slotPixelH;
+            const rad = (t.rotationDegrees || 0) * Math.PI/180;
+            ctx.save(); ctx.translate(slotPixelW/2 + tx, slotPixelH/2 + ty); if (rad) ctx.rotate(rad); ctx.scale(scale, scale); ctx.drawImage(img, -img.width/2, -img.height/2); ctx.restore();
+            const png = await canvasToPngBytes(canvas);
+            const embedded = await pdf.embedPng(png);
+            page.drawImage(embedded, { x, y, width: slotPointW, height: slotPointH });
+        }
+      }
+    }
+    // Calendar grid (reuse logic simplified from standard export)
+    const g = layout.grid;
+    const baseGx = g.x * width;
+    const baseGy = height - (g.y * height) - (g.h * height);
+    const baseGw = g.w * width;
+    const baseGh = g.h * height;
+    const safeInset = 0.125 * 72;
+    const gx = baseGx + safeInset;
+    const gy = baseGy + safeInset;
+    const gw = Math.max(10, baseGw - safeInset * 2);
+    const gh = Math.max(10, baseGh - safeInset * 2);
+    const columns = 7;
+    const cellH = gh / 7; // header + 6 weeks
+    const cellW = gw / columns;
+    // Month label
+    const monthNames = ['January','February','March','April','May','June','July','August','September','October','November','December'];
+    const monthLabel = `${monthNames[realMonth0]} ${realYear}`;
+    page.drawRectangle({ x: gx, y: gy + gh - cellH, width: gw, height: cellH, color: rgb(0.96,0.96,0.96) });
+    const labelSize = 16; const labelWidth = font.widthOfTextAtSize(monthLabel, labelSize);
+    page.drawText(monthLabel, { x: gx + (gw - labelWidth)/2, y: gy + gh - labelSize - 2, size: labelSize, font, color: rgb(0,0,0) });
+    const weekDayLabels = ['Sun','Mon','Tue','Wed','Thu','Fri','Sat'];
+    weekDayLabels.forEach((d,i)=>{ const cx = gx + i*cellW; page.drawText(d, { x: cx + 4, y: gy + gh - cellH + 8, size:10, font, color: rgb(0,0,0) }); });
+    for (let r=0;r<=7;r++){ if (r===7) continue; const y = gy + r*cellH; page.drawLine({ start:{x:gx,y}, end:{x:gx+gw,y}, thickness:0.5, color: rgb(0.8,0.8,0.8)}); }
+    const headerBottomY = gy + gh - cellH;
+    for (let c=0;c<=columns;c++){ const x = gx + c*cellW; page.drawLine({ start:{x,y:gy}, end:{x,y:headerBottomY}, thickness:0.5, color: rgb(0.8,0.8,0.8)}); }
+    // days
+    const grid = generateMonthGrid(realYear, realMonth0);
+    const events = project.events.filter(e => e.visible && e.dateISO.startsWith(`${realYear}-${String(realMonth0+1).padStart(2,'0')}`));
+    for (let w=0; w<grid.weeks.length; w++) {
+      const week = grid.weeks[w];
+      for (let d=0; d<week.length; d++) {
+        const cell = week[d];
+        const cx = gx + d*cellW;
+        const cy = gy + gh - (w + 2) * cellH;
+        if (cell.inMonth && cell.day) {
+          page.drawText(String(cell.day), { x: cx+4, y: cy + cellH - 14, size:10, font, color: rgb(0,0,0) });
+          const dateISO = `${realYear}-${String(realMonth0+1).padStart(2,'0')}-${String(cell.day).padStart(2,'0')}`;
+          const cellEvents = events.filter(e => e.dateISO === dateISO).slice(0,2);
+          const textSize = 9; const lineHeight = 10; let lineIdx = 0; const maxWidth = cellW - 8;
+          cellEvents.forEach(ev => {
+            const color = parseHexColor(ev.color);
+            const words = ev.text.split(/\s+/); let current=''; const lines:string[]=[];
+            words.forEach(wd=>{ const test = current? current+' '+wd: wd; const widthW = font.widthOfTextAtSize(test, textSize); if (widthW <= maxWidth) current=test; else { if (current) lines.push(current); current=wd; } }); if (current) lines.push(current);
+            lines.slice(0,2).forEach(line=>{ const yLine = cy + cellH - 28 - (lineIdx * lineHeight); if (yLine > cy + 2) { page.drawText(line, { x: cx+4, y: yLine, size: textSize, font, color }); lineIdx++; } });
+          });
+        }
+      }
+    }
+    // Rotate page if needed
+    if (ps.upsideDown) {
+      page.setRotation(degrees(180));
+    }
+    pageCounter++; if (onProgress) onProgress(pageCounter / totalPages);
+  }
+  if (hasCover) {
+    // Reuse existing cover export simplified: just a blank cover with label for now
+    const { pageSize, orientation } = project.calendar;
+    const pt = computePagePixelSize(pageSize, orientation, 72);
+    const cover = pdf.addPage([pt.width, pt.height]);
+    const { width, height } = cover.getSize();
+    const label = 'Cover';
+    const size = 32; const textW = font.widthOfTextAtSize(label, size);
+    cover.drawText(label, { x: (width - textW)/2, y: height/2 - size/2, size, font, color: rgb(0,0,0) });
+    pageCounter++; if (onProgress) onProgress(pageCounter / totalPages);
+  }
+  const bytes = await pdf.save();
+  const ab = new ArrayBuffer(bytes.byteLength); new Uint8Array(ab).set(bytes);
+  const blob = new Blob([ab], { type: 'application/pdf' });
+  const url = URL.createObjectURL(blob); const a = document.createElement('a'); a.href = url; a.download = 'calendar-foldable.pdf'; a.click(); URL.revokeObjectURL(url);
 }


### PR DESCRIPTION
This pull request introduces support for foldable calendar exports and significantly expands cover photo handling, including separate front and rear cover images with independent transforms and selection modals. It also refines the photo interaction experience for both cover and month photos, ensuring consistent drag, zoom, and rotation controls. The store and types have been updated to support these new features.

**Foldable calendar export:**

* Added a new export action and utility (`exportProjectFoldable`, `exportAsPdfFoldable`) to generate foldable calendar PDFs, with appropriate UI feedback and error handling. [[1]](diffhunk://#diff-b6dccdeff4ac0c74bf56d6387fb90af19ebd8718059842bad86fa1ef79482b4bR50) [[2]](diffhunk://#diff-b6dccdeff4ac0c74bf56d6387fb90af19ebd8718059842bad86fa1ef79482b4bR216-R230) [[3]](diffhunk://#diff-b6dccdeff4ac0c74bf56d6387fb90af19ebd8718059842bad86fa1ef79482b4bL7-R7)
* Documented the page order and layout for foldable calendars in `FoldableSpecs.md`.

**Cover photo enhancements:**

* Extended `CalendarSettings` and store actions to support separate `frontCoverPhotoId`, `rearCoverPhotoId`, and their respective transforms, along with legacy cover support. [[1]](diffhunk://#diff-c54113cf61ec99691748a3890bfbeb00e10efb3f0a76f03a0fd9ec49072e410aL36-R36) [[2]](diffhunk://#diff-b6dccdeff4ac0c74bf56d6387fb90af19ebd8718059842bad86fa1ef79482b4bR34-R41) [[3]](diffhunk://#diff-b6dccdeff4ac0c74bf56d6387fb90af19ebd8718059842bad86fa1ef79482b4bR126-R127) [[4]](diffhunk://#diff-b6dccdeff4ac0c74bf56d6387fb90af19ebd8718059842bad86fa1ef79482b4bR142-R159)
* Added UI state and actions for opening/closing a unified cover photo picker modal, and for selecting/clearing cover photos for each position. [[1]](diffhunk://#diff-b6dccdeff4ac0c74bf56d6387fb90af19ebd8718059842bad86fa1ef79482b4bR18) [[2]](diffhunk://#diff-b6dccdeff4ac0c74bf56d6387fb90af19ebd8718059842bad86fa1ef79482b4bR74-R75) [[3]](diffhunk://#diff-b6dccdeff4ac0c74bf56d6387fb90af19ebd8718059842bad86fa1ef79482b4bL77-R87) [[4]](diffhunk://#diff-b6dccdeff4ac0c74bf56d6387fb90af19ebd8718059842bad86fa1ef79482b4bR295-R296)
* Introduced a new reusable component `CoverPhotoUnifiedPreview` for consistent cover photo interaction (pan/zoom/rotate/clear/change) across legacy, front, and rear covers.
* Integrated the new cover picker modal into the app shell. [[1]](diffhunk://#diff-0022b32944774e72bcbec1b0520e753925073bfbeff256269d0f668f5f515b0eL8-R8) [[2]](diffhunk://#diff-0022b32944774e72bcbec1b0520e753925073bfbeff256269d0f668f5f515b0eR53)

**Photo interaction consistency:**

* Updated month photo drag/zoom/rotate logic and CSS in `PagePreview` to match the new cover photo interaction, including locking page scroll during drag for smoother UX. [[1]](diffhunk://#diff-4bc491f2c13d81d353282d9d9e5031f6b87fe1c495579b3dfd4333d89671e662L64-R71) [[2]](diffhunk://#diff-4bc491f2c13d81d353282d9d9e5031f6b87fe1c495579b3dfd4333d89671e662R92-R95)

These changes collectively improve the flexibility and user experience for calendar exports and cover customization.